### PR TITLE
SE350: Add example repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Sample SE Resumes:
 - https://cve.mitre.org/index.html
 - https://nordpass.com/most-common-passwords-list/
 - https://haveibeenpwned.com/
+- [simcard0000's se350-examples](https://github.com/simcard0000/se350-examples)
 
 ### SE 465 - Software Testing and Quality Assurance
 - https://cs.gmu.edu:8443/offutt/coverage/LogicCoverage


### PR DESCRIPTION
In the SE350 section, I added a link to a repo I made that contains all the code examples from the SE350 class: https://github.com/simcard0000/se350-examples. Thanks!